### PR TITLE
support using podman instead of docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM zmkfirmware/zmk-build-arm:stable
+FROM docker.io/zmkfirmware/zmk-build-arm:stable
 
 WORKDIR /app
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
 TIMESTAMP := $(shell date -u +"%Y%m%d%H%M%S")
+DOCKER := $(shell { command -v podman || command -v docker; })
 
 .PHONY: clean setup
 
@@ -10,11 +11,11 @@ clean:
 	rm ./firmware/*.uf2
 
 firmware/%-left.uf2 firmware/%-right.uf2: config/adv360.keymap
-	docker run --rm -it --name zmk \
+	$(DOCKER) run --rm -it --name zmk \
 		-v $(PWD)/firmware:/app/firmware \
 		-v $(PWD)/config:/app/config:ro \
 		-e TIMESTAMP=$(TIMESTAMP) \
 		zmk
 
 setup: Dockerfile bin/build.sh config/west.yml
-	docker build --tag zmk --file Dockerfile .
+	$(DOCKER) build --tag zmk --file Dockerfile .

--- a/README.md
+++ b/README.md
@@ -12,9 +12,11 @@
 1. Push a commit to trigger the build.
 2. Download the artifact.
 
-## To build Firmware locally using Docker
+## To build Firmware locally using a container
 
 ### First run
+
+Note: Either Podman or Docker is required, Podman is preferred if both are present.
 
 1. Execute `make all`.
 2. Check the `firmware` directory for the latest firmware build.


### PR DESCRIPTION
podman has many advantages over docker (e.g. rootless by default), this allows falling back to podman if the docker command is not present.