### PR TITLE
fix local docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM zmkfirmware/zmk-build-arm:2.4
+FROM zmkfirmware/zmk-build-arm:stable
 
 RUN mkdir -p /app/firmware
 


### PR DESCRIPTION
Looks like this broke when the V2.0 branch became the new default.