### PR TITLE
Reusable Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM zmkfirmware/zmk-build-arm:stable
+FROM zmkfirmware/zmk-build-arm:2.4
 
 WORKDIR /app
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,6 @@ RUN west update
 # West Zephyr export
 RUN west zephyr-export
 
-COPY config config
 COPY bin/build.sh ./
 
 CMD ["./build.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,4 @@
-FROM zmkfirmware/zmk-build-arm:2.4
-
-RUN mkdir -p /app/firmware
+FROM zmkfirmware/zmk-build-arm:stable
 
 WORKDIR /app
 

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,21 @@
+.PHONY: clean timestamp setup
+
+all: setup build
+
+build: timestamp firmware/$$(TIMESTAMP)-left.uf2 firmware/$$(TIMESTAMP)-right.uf2
+
+clean:
+	rm ./firmware/*.uf2
+
+firmware/%-left.uf2 firmware/%-right.uf2: config/adv360.keymap timestamp
+	docker run --rm -it --name zmk \
+		-v $(PWD)/firmware:/app/firmware \
+		-v $(PWD)/config:/app/config:ro \
+		-e TIMESTAMP=$(TIMESTAMP) \
+		zmk
+
+setup:
+	docker build --tag zmk .
+
+timestamp:
+	$(eval TIMESTAMP:=$(shell date -u +"%Y%m%d%H%M%S"))

--- a/Makefile
+++ b/Makefile
@@ -14,8 +14,8 @@ firmware/%-left.uf2 firmware/%-right.uf2: config/adv360.keymap timestamp
 		-e TIMESTAMP=$(TIMESTAMP) \
 		zmk
 
-setup:
-	docker build --tag zmk .
+setup: Dockerfile bin/build.sh config/west.yml
+	docker build --tag zmk --file Dockerfile .
 
 timestamp:
 	$(eval TIMESTAMP:=$(shell date -u +"%Y%m%d%H%M%S"))

--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,15 @@
-.PHONY: clean timestamp setup
+TIMESTAMP := $(shell date -u +"%Y%m%d%H%M%S")
+
+.PHONY: clean setup
 
 all: setup build
 
-build: timestamp firmware/$$(TIMESTAMP)-left.uf2 firmware/$$(TIMESTAMP)-right.uf2
+build: firmware/$$(TIMESTAMP)-left.uf2 firmware/$$(TIMESTAMP)-right.uf2
 
 clean:
 	rm ./firmware/*.uf2
 
-firmware/%-left.uf2 firmware/%-right.uf2: config/adv360.keymap timestamp
+firmware/%-left.uf2 firmware/%-right.uf2: config/adv360.keymap
 	docker run --rm -it --name zmk \
 		-v $(PWD)/firmware:/app/firmware \
 		-v $(PWD)/config:/app/config:ro \
@@ -16,6 +18,3 @@ firmware/%-left.uf2 firmware/%-right.uf2: config/adv360.keymap timestamp
 
 setup: Dockerfile bin/build.sh config/west.yml
 	docker build --tag zmk --file Dockerfile .
-
-timestamp:
-	$(eval TIMESTAMP:=$(shell date -u +"%Y%m%d%H%M%S"))

--- a/README.md
+++ b/README.md
@@ -14,14 +14,16 @@
 
 ## To build Firmware locally using Docker
 
-### Setup
+### First run
 
-1. Execute `setup.sh`.
-
-### Build firmware
-
-1. Execute `run.sh`
+1. Execute `make all`.
 2. Check the `firmware` directory for the latest firmware build.
+
+### Subsequent runs
+
+If the only file you have changed is `config/adv360.keymap`, execute `make build` and check the `firmware` directory for the latest firmware build.
+
+If you have changed other files in the `config` directory (such as `config/west.yml`) you will need to execute `make all` to rebuild the Docker image as well as the firmware.
 
 ### Flash firmware
 

--- a/bin/build.sh
+++ b/bin/build.sh
@@ -1,9 +1,9 @@
 #!/usr/bin/env bash
 
-set -e
+set -eu
 
 PWD=$(pwd)
-TIMESTAMP=$(date -u +"%Y%m%d%H%M%S")
+TIMESTAMP="${TIMESTAMP:-$(date -u +"%Y%m%d%H%M%S")}"
 
 # West Build (left)
 west build -s zmk/app -d build/left -b adv360_left -- -DZMK_CONFIG="${PWD}/config"

--- a/run.sh
+++ b/run.sh
@@ -1,8 +1,0 @@
-#!/usr/bin/env bash
-
-set -e
-
-docker run -it --name zmk zmk
-docker cp zmk:/app/firmware/ ./
-docker stop zmk
-docker rm zmk

--- a/setup.sh
+++ b/setup.sh
@@ -1,5 +1,0 @@
-#!/usr/bin/env bash
-
-set -e
-
-docker build --tag zmk .


### PR DESCRIPTION
I'm sure there are considerations that my own preferred workflow doesn't account for, so consider this PR more as a starting point for further discussion. But in brief, it's not strictly necessary to rebuild the Docker image if all you've updated is your keymap. This PR creates a reusable Docker image that can persist between firmware builds by simply mounting the `config` and `firmware` directories at runtime.

### Pros:
- On my machine, building the Docker image takes ~120s. We can eliminate that if there's no need to update West or its config.
- Currently if the build fails, sometimes the `zmk` container is left around and needs to be manually removed. Using `docker run --rm ...` ensures the container is always cleaned up regardless of success.
- Makefile is arguably a better starting point for people who want to customize their build scripts -- targets can be added without clobbering the "official" workflow.

### Cons:
- One side effect of running `setup.sh` every time is that zmk/west are always up to date. Making the Docker rebuild an optional step puts the responsibility on the end user to update those deps by manually rebuilding the image.
- Related to the above, it's not inherently obvious when the Docker image needs to be rebuilt. I've tried to address this in the Readme.
- Adds `make` to the mix, although if someone is already willing to run Docker locally I think it's a safe bet they have some familiarity with `make`.

Ultimately you could just instruct people to run `make all` (or even just `make`) and they'd get the same experience they do currently; this just adds a little more control over the build process for people who want it.