### PR TITLE
makefile: ignore errors during clean

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ all: setup build
 build: firmware/$$(TIMESTAMP)-left.uf2 firmware/$$(TIMESTAMP)-right.uf2
 
 clean:
-	rm ./firmware/*.uf2
+	rm -f firmware/*.uf2
 
 firmware/%-left.uf2 firmware/%-right.uf2: config/adv360.keymap
 	docker run --rm -it --name zmk \


### PR DESCRIPTION
The file(s) being removed may not exist, but make shouldn't fail because of it:

        $ make clean
        rm ./firmware/*.uf2
        rm: cannot remove './firmware/*.uf2': No such file or directory
        make: *** [Makefile:10: clean] Error 1
        $ echo $?
        2

-f silences any output from rm even though the single dash tells make to ignore the failure, which just creates noise.