### PR TITLE
Disable SELinux support on OS X

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,21 @@
 DOCKER := $(shell { command -v podman || command -v docker; })
 TIMESTAMP := $(shell date -u +"%Y%m%d%H%M%S")
+detected_OS := $(shell uname)  # Classify UNIX OS
+ifeq ($(detected_OS),Darwin) #We only care if it's OS X
+SELINUX1 :=
+SELINUX2 :=
+else
+SELINUX1 := :z
+SELINUX2 := ,z
+endif
 
 .PHONY: all clean
 
 all:
 	$(DOCKER) build --tag zmk --file Dockerfile .
 	$(DOCKER) run --rm -it --name zmk \
-		-v $(PWD)/firmware:/app/firmware:z \
-		-v $(PWD)/config:/app/config:ro,z \
+		-v $(PWD)/firmware:/app/firmware$(SELINUX1) \
+		-v $(PWD)/config:/app/config:ro$(SELINUX2) \
 		-e TIMESTAMP=$(TIMESTAMP) \
 		zmk
 

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 DOCKER := $(shell { command -v podman || command -v docker; })
 TIMESTAMP := $(shell date -u +"%Y%m%d%H%M%S")
 detected_OS := $(shell uname)  # Classify UNIX OS
-ifeq ($(detected_OS),Darwin) #We only care if it's OS X
+ifeq ($(strip $(detected_OS)),Darwin) #We only care if it's OS X
 SELINUX1 :=
 SELINUX2 :=
 else


### PR DESCRIPTION
Uses uname to classify the operating system and disables the SELinux 'z' flag if that's determined to be the case, should resolve #90 