### PR TITLE
Fix shell check warnings

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,11 +36,11 @@ jobs:
       - name: West Build (left)
         run: west build -s zmk/app -d build/left -b adv360_left -- -DZMK_CONFIG="${GITHUB_WORKSPACE}/config"
       - name: Adv360 Left Kconfig file
-        run: cat build/left/zephyr/.config | grep -v "^#" | grep -v "^$"
+        run: grep -vE '(^#|^$)' build/left/zephyr/.config
       - name: West Build (right)
         run: west build -s zmk/app -d build/right -b adv360_right -- -DZMK_CONFIG="${GITHUB_WORKSPACE}/config"
       - name: Adv360 Right Kconfig file
-        run: cat build/right/zephyr/.config | grep -v "^#" | grep -v "^$"
+        run: grep -vE '(^#|^$)' build/right/zephyr/.config
       - name: Rename zmk.uf2
         run: cp build/left/zephyr/zmk.uf2 left.uf2 && cp build/right/zephyr/zmk.uf2 right.uf2
       - name: Archive (Adv360)

--- a/bin/build.sh
+++ b/bin/build.sh
@@ -14,4 +14,4 @@ west build -s zmk/app -d build/right -b adv360_right -- -DZMK_CONFIG="${PWD}/con
 # Adv360 Right Kconfig file
 grep -vE '(^#|^$)' build/right/zephyr/.config
 # Rename zmk.uf2
-cp build/left/zephyr/zmk.uf2 ./firmware/${TIMESTAMP}-left.uf2 && cp build/right/zephyr/zmk.uf2 ./firmware/${TIMESTAMP}-right.uf2
+cp build/left/zephyr/zmk.uf2 "./firmware/${TIMESTAMP}-left.uf2" && cp build/right/zephyr/zmk.uf2 "./firmware/${TIMESTAMP}-right.uf2"

--- a/bin/build.sh
+++ b/bin/build.sh
@@ -8,10 +8,10 @@ TIMESTAMP="${TIMESTAMP:-$(date -u +"%Y%m%d%H%M%S")}"
 # West Build (left)
 west build -s zmk/app -d build/left -b adv360_left -- -DZMK_CONFIG="${PWD}/config"
 # Adv360 Left Kconfig file
-cat build/left/zephyr/.config | grep -v "^#" | grep -v "^$"
+grep -vE '(^#|^$)' build/left/zephyr/.config
 # West Build (right)
 west build -s zmk/app -d build/right -b adv360_right -- -DZMK_CONFIG="${PWD}/config"
 # Adv360 Right Kconfig file
-cat build/right/zephyr/.config | grep -v "^#" | grep -v "^$"
+grep -vE '(^#|^$)' build/right/zephyr/.config
 # Rename zmk.uf2
 cp build/left/zephyr/zmk.uf2 ./firmware/${TIMESTAMP}-left.uf2 && cp build/right/zephyr/zmk.uf2 ./firmware/${TIMESTAMP}-right.uf2


### PR DESCRIPTION
## Description of changes

- `SC2002` -- piping `cat` through two `grep` calls may instead be handled all by one `grep` call within both the GitHub Action configuration, and build script.
   > Note; I recognize above described change is totally a _micro_ optimization, but it also reduces `shellcheck` noise and _shouldn't_ break anything
- `SC2086` -- double quoting prevents unintentional word splitting were one to call script with `TIMESTAMP` defined, ex `TIMESTAMP="questionable idea" ./bin/build.sh`

## Related documentation

- https://www.shellcheck.net/wiki/SC2002
- https://www.shellcheck.net/wiki/SC2086

## GitHub Action

- https://github.com/S0AndS0/Adv360-Pro-ZMK/actions/runs/6436664594
