### PR TITLE
Update Makefile variables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Here's all notable changes and commits to both the configuration repo and the ba
 Many thanks to all those who have submitted issues and pull requests to make this firmware better!
 ## Config repo
 
+1/16/2024 - Change the makefile to fis WSL2 compatibility [#335](https://github.com/KinesisCorporation/Adv360-Pro-ZMK/pull/335)
+
 1/14/2024 - Update base ZMK, change KConfig attributes to support, Enable experimental BLE features for improved stability [#326](https://github.com/KinesisCorporation/Adv360-Pro-ZMK/pull/326)
 
 12/27/2023 - Change how the characters are used in the versioning script for improved MacOS experience [#303](https://github.com/KinesisCorporation/Adv360-Pro-ZMK/pull/303)

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
-DOCKER := $(shell { command -v podman || command -v docker; })
-TIMESTAMP := $(shell date -u +"%Y%m%d%H%M")
-COMMIT := $(shell git rev-parse --short HEAD 2>/dev/null)
-detected_OS := $(shell uname)  # Classify UNIX OS
+DOCKER := "$(shell { command -v podman || command -v docker; })"
+TIMESTAMP := "$(shell date -u +"%Y%m%d%H%M")"
+COMMIT := "$(shell git rev-parse --short HEAD 2>/dev/null)"
+detected_OS := "$(shell uname)"  # Classify UNIX OS
 ifeq ($(strip $(detected_OS)),Darwin) #We only care if it's OS X
 SELINUX1 :=
 SELINUX2 :=


### PR DESCRIPTION
## Advantage 360 Pro PR template

### What's changed: 
Adds quotes around the makefile variables to fix WSL2 compatibilty

### Why has this change been implemented: 
Commit https://github.com/KinesisCorporation/Adv360-Pro-ZMK/commit/1728a660cea95760573a72bbf0f6b1da68342749 broke WSL2 compatibility. Fixes #317 

### What (if any) actions must a user take after this change: 
No actions required

