### PR TITLE
Fix MacOS makefile vvars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Here's all notable changes and commits to both the configuration repo and the ba
 Many thanks to all those who have submitted issues and pull requests to make this firmware better!
 ## Config repo
 
+1/17/2023 - Handle makefile variables differently on MacOS to fix  issue introduced with WSL2 fix [#338](https://github.com/KinesisCorporation/Adv360-Pro-ZMK/pull/338)
+
 1/16/2024 - Change the makefile to fis WSL2 compatibility [#335](https://github.com/KinesisCorporation/Adv360-Pro-ZMK/pull/335)
 
 1/14/2024 - Update base ZMK, change KConfig attributes to support, Enable experimental BLE features for improved stability [#326](https://github.com/KinesisCorporation/Adv360-Pro-ZMK/pull/326)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Here's all notable changes and commits to both the configuration repo and the ba
 Many thanks to all those who have submitted issues and pull requests to make this firmware better!
 ## Config repo
 
-1/17/2023 - Handle makefile variables differently on MacOS to fix  issue introduced with WSL2 fix [#338](https://github.com/KinesisCorporation/Adv360-Pro-ZMK/pull/338)
+1/17/2023 - Handle makefile variables differently on MacOS to fix  issue introduced with WSL2 fix [#339](https://github.com/KinesisCorporation/Adv360-Pro-ZMK/pull/339)
 
 1/16/2024 - Change the makefile to fis WSL2 compatibility [#335](https://github.com/KinesisCorporation/Adv360-Pro-ZMK/pull/335)
 

--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,14 @@
-DOCKER := "$(shell { command -v podman || command -v docker; })"
-TIMESTAMP := "$(shell date -u +"%Y%m%d%H%M")"
-COMMIT := "$(shell git rev-parse --short HEAD 2>/dev/null)"
-detected_OS := "$(shell uname)"  # Classify UNIX OS
+detected_OS := $(shell uname)  # Classify UNIX OS
 ifeq ($(strip $(detected_OS)),Darwin) #We only care if it's OS X
+DOCKER := $(shell { command -v podman || command -v docker; })
+TIMESTAMP := $(shell date -u +"%Y%m%d%H%M")
+COMMIT := $(shell git rev-parse --short HEAD 2>/dev/null)
 SELINUX1 :=
 SELINUX2 :=
 else
+DOCKER := "$(shell { command -v podman || command -v docker; })"
+TIMESTAMP := "$(shell date -u +"%Y%m%d%H%M")"
+COMMIT := "$(shell git rev-parse --short HEAD 2>/dev/null)"
 SELINUX1 := :z
 SELINUX2 := ,z
 endif


### PR DESCRIPTION
## Advantage 360 Pro PR template

### What's changed:

The OS auto detection in the makefile has been expanded so more variables are not quoted when running under MacOS

### Why has this change been implemented:

#335 Broke compatibility on MacOS

### What (if any) actions must a user take after this change:

No additional actions need to be taken

