### PR TITLE
Fix version.dtsi is reset after local firmware build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Here's all notable changes and commits to both the configuration repo and the ba
 Many thanks to all those who have submitted issues and pull requests to make this firmware better!
 ## Config repo
 
+18/2/2024 - Fix version.dtsi reset after build when running local builds [#385](https://github.com/KinesisCorporation/Adv360-Pro-ZMK/pull/385)
+
 12/2/2024 - Update GitHub build workflow to use the latest actions [#376](https://github.com/KinesisCorporation/Adv360-Pro-ZMK/pull/376)
 
 2/2/2024 - Makefile enhancements (build left side firmware only, separate clean targets for firmware and docker, reset of version.dtsi after build) [#363](https://github.com/KinesisCorporation/Adv360-Pro-ZMK/pull/363)

--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ all:
 		-e COMMIT=$(COMMIT) \
 		-e BUILD_RIGHT=true \
 		zmk
-	$(shell git checkout config/version.dtsi)
+	git checkout config/version.dtsi
 
 left:
 	$(shell bin/get_version.sh >> /dev/null)
@@ -34,7 +34,7 @@ left:
 		-e COMMIT=$(COMMIT) \
 		-e BUILD_RIGHT=false \
 		zmk
-	$(shell git checkout config/version.dtsi)
+	git checkout config/version.dtsi
 
 clean_firmware:
 	rm -f firmware/*.uf2


### PR DESCRIPTION
## Advantage 360 Pro PR template

I discovered yesterday that the command I introduced in #376 to reset the version.dtsi file after a local build to reduce noise on code changes to repositories is not behaving as intended and went undetected during my testing given that my checked in version.dtsi was from the same day and branch. Apologies for that.

### What's changed:

This change updates how the git command to reset the version.dtsi is being called. It is no longer called within a shell function to ensure it does run in the order it is defined after the firmware build is complete.

### Why has this change been implemented:

In #376 a new step was introduced for local builds to undo changes to the version.dtsi file after a build in order to reduce noise to the repo.

Unfortunately the way used to execute the step causes the version.dtsi file to be reset too early and therefore causes an incorrect version number to be used for the version macro when run locally. This went unfortunately undiscovered as the checked in version.dtsi was the same on the day the change in #376 was tested and was not noticed until I build a new change to my keymap locally a few days ago.

The git command introduced in #376 is wrapped into a shell function.

However what was missed is that commands run by the shell function are run when the function calls are expanded by make. This causes the version.dtsi file to be reset before the firmware build process is even started which resultes in the version.dtsi currently checked in to the repo to be used for local builds instead of the newly generated file when make starts.

Builds run through GitHub actions are not impacted and always used the correct version.dtsi

For more information and context see:
  - https://www.gnu.org/software/make/manual/html_node/Shell-Function.html
  - https://www.gnu.org/software/make/manual/html_node/Reading-Makefiles.html

### What (if any) actions must a user take after this change:

No further actions must be taken by users. Local builds will start using the correct version number generated by `bin/get_version.sh` again while maintaining the reset of the version.dtsi file after a local firmware build is complete.