### PR TITLE
Fix Makefile errors that prevent builds on macOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Here's all notable changes and commits to both the configuration repo and the ba
 Many thanks to all those who have submitted issues and pull requests to make this firmware better!
 ## Config repo
 
+14/3/2024 - Fix Makefile errors that prevent builds on macOS [#409](https://github.com/KinesisCorporation/Adv360-Pro-ZMK/pull/409)
+
 18/2/2024 - Fix version.dtsi reset after build when running local builds [#385](https://github.com/KinesisCorporation/Adv360-Pro-ZMK/pull/385)
 
 12/2/2024 - Update GitHub build workflow to use the latest actions [#376](https://github.com/KinesisCorporation/Adv360-Pro-ZMK/pull/376)

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,7 @@
-DOCKER := "$(shell { command -v podman || command -v docker; })"
-TIMESTAMP := "$(shell date -u +"%Y%m%d%H%M")"
-COMMIT := "$(shell git rev-parse --short HEAD 2>/dev/null)"
-detected_OS := "$(shell uname)"  # Classify UNIX OS
-ifeq ($(strip $(detected_OS)),Darwin) #We only care if it's OS X
+DOCKER := $(shell { command -v podman || command -v docker; })
+TIMESTAMP := $(shell date -u +"%Y%m%d%H%M")
+COMMIT := $(shell git rev-parse --short HEAD 2>/dev/null)
+ifeq ($(shell uname),Darwin)
 SELINUX1 :=
 SELINUX2 :=
 else


### PR DESCRIPTION
### What's changed:

Remove unnecessary quotes from variable assignments, errant comments, and an unnecessary call to `strip`. I also inlined the variable `detected_OS` since it's only used in one place.

### Why has this change been implemented:

Back in January 2023, some changes were made to `Makefile` to drop some flags that aren't available in macOS builds that were causing those builds to fail.

Unfortunately, these changes had a few small syntax issues that prevent the conditional checks for "Darwin" from ever being true. See commits 0e19696, d011eea, 0737d53.

Specifically, a trailing comment after a variable assignment with spaces before the comment character actually has the effect of adding those trailing spaces to the variable being assigned (`detected_OS`). The subsequent line attempts to strip these spaces, but inadvertently adds them back with another trailing comment. Further, the quotes around these assignments added in commit 0737d53 also end up verbatim in the variable's value. The consequence of this the comparison actually ends up comparing `"Darwin" ` with `Darwin`, so the check never succeeds and the wrong flags are used. You can confirm this by adding

    echo .$(detected_OS).

to the `all` target and running make. You'll see the quotes and extra spaces between the dots when the echo command is written to the console (the quotes are eaten by the shell when echo is executed).

### What (if any) actions must a user take after this change:
No user actions necessary. I tested these changes on macOS 14.4 and Ubuntu Linux 22.04.4 LTS
