### PR TITLE
Local build changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Here's all notable changes and commits to both the configuration repo and the ba
 Many thanks to all those who have submitted issues and pull requests to make this firmware better!
 ## Config repo
 
+2/9/2025 - Minor changes to the local build process to improve local building experience, Remove preprocessor commands in keymap file [#643](https://github.com/KinesisCorporation/Adv360-Pro-ZMK/pull/643)
+
 2/6/2025 - Update base ZMK, add changes to support Kinesis Clique, update RGB parameters and enable pointing support [#630](https://github.com/KinesisCorporation/Adv360-Pro-ZMK/pull/630)
 
 11/27/2024 - Fix misattributed PR link in changelog [#590](https://github.com/KinesisCorporation/Adv360-Pro-ZMK/pull/590)

--- a/bin/build.sh
+++ b/bin/build.sh
@@ -16,7 +16,7 @@ cp build/left/zephyr/zmk.uf2 "./firmware/${TIMESTAMP}-${COMMIT}-left-clique.uf2"
 # Build right side if selected
 if [ "${BUILD_RIGHT}" = true ]; then
     # West Build (right)
-    west build -s zmk/app -p -d build/right -b adv360_right -S studio-rpc-usb-uart -- -DZMK_CONFIG="${PWD}/config" -DCONFIG_ZMK_STUDIO=y
+    west build -s zmk/app -p -d build/right -b adv360_right -- -DZMK_CONFIG="${PWD}/config"
     # Adv360 Right Kconfig file
     grep -vE '(^#|^$)' build/right/zephyr/.config
     # Rename zmk.uf2

--- a/bin/get_version_local.sh
+++ b/bin/get_version_local.sh
@@ -67,7 +67,6 @@ echo $formatted_result
 echo '#define VERSION_MACRO' > "config/version.dtsi"
 echo 'macro_ver: macro_ver {' >> "config/version.dtsi"
 echo 'compatible = "zmk,behavior-macro";' >> "config/version.dtsi"
-echo 'display-name = "Version Macro";' >> "config/version.dtsi"
 echo '#binding-cells = <0>;' >> "config/version.dtsi"
 echo "bindings = $formatted_result;" >> "config/version.dtsi"
 echo '};' >> "config/version.dtsi"

--- a/config/adv360.keymap
+++ b/config/adv360.keymap
@@ -10,14 +10,6 @@
     behaviors {
       #include "macros.dtsi"
       #include "version.dtsi"
-      #ifndef VERSION_MACRO
-      macro_ver: macro_ver {
-        compatible = "zmk,behavior-macro";
-        label = "macro_version";
-        #binding-cells = <0>;
-        bindings = <&kp RET>;
-      };
-      #endif
 
       hm: homerow_mods {
           compatible = "zmk,behavior-hold-tap";


### PR DESCRIPTION
## Advantage 360 Pro PR template

### What's changed:

Change the local build process to not add an unused serial port into the right side firmware
Remove preprocessor commands from keymap file

### Why has this change been implemented:

Having the serial port on the right side is unnecessary as it is unused
The preprocessor commands on the keymap file conflicted with some graphical keymap editors when adding new macros

### What (if any) actions must a user take after this change:

No additional changes should be necessary
