### PR TITLE
feat: Migrate German layout to V3.0

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,23 @@
+{
+	"name": "Ubuntu",
+	"image": "mcr.microsoft.com/devcontainers/base:jammy",
+
+	"containerEnv": {
+		"CODESPACES": "True"
+	}
+
+	// Features to add to the dev container. More info: https://containers.dev/features.
+	// "features": {},
+
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	// "forwardPorts": [],
+
+	// Use 'postCreateCommand' to run commands after the container is created.
+	// "postCreateCommand": "uname -a",
+
+	// Configure tool-specific properties.
+	// "customizations": {},
+
+	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
+	// "remoteUser": "root"
+}

--- a/config/adv360_custom.keymap
+++ b/config/adv360_custom.keymap
@@ -1,0 +1,123 @@
+/*
+Todo:
+* check for macros lead keys
+* clean up all layouts add trans / none and use better spacing
+* add hyper and fancy zones shortcuts / macros
+* use os specific defines for shortcuts
+*/
+#include "keymap_german.h"
+
+#include <behaviors.dtsi>
+#include <dt-bindings/zmk/keys.h>
+#include <dt-bindings/zmk/bt.h>
+#include <dt-bindings/zmk/rgb.h>
+#include <dt-bindings/zmk/backlight.h>
+
+#define DEFAULT 0
+#define LOWER   1
+#define RAISE   2
+#define ADJ     3
+#define KPAD    4
+#define FN      5
+
+// Shortcut definitions
+// Windows
+#define WLOCK LEFT_GUI(L)  // Lock Screen
+#define WNWIN LS(LA(ESC))  // Focus to previous window
+#define WPWIN LA(ESC)      // Focus to next window
+#define WTASK LC(LS(ESC))  // Task Manager
+#define WPSCR RG(LS(S))    // Screnshot using screenshot tool
+
+/ {
+    behaviors {
+      #include "macros.dtsi"
+      #include "version.dtsi"
+      #ifndef VERSION_MACRO
+      macro_ver: macro_ver {
+        compatible = "zmk,behavior-macro";
+        label = "macro_version";
+        #binding-cells = <0>;
+        bindings = <&kp RET>;
+      };
+      #endif
+
+      hm: homerow_mods {
+          compatible = "zmk,behavior-hold-tap";
+          label = "HOMEROW_MODS";
+          #binding-cells = <2>;
+          tapping-term-ms = <200>;
+          quick_tap_ms = <175>;
+          flavor = "tap-preferred";
+          bindings = <&kp>, <&kp>;
+      };
+    };
+
+    // Tre-layer support
+    conditional_layers {
+        compatible = "zmk,conditional-layers";
+        tri_layer {
+            if-layers = <LOWER RAISE>;
+            then-layer = <ADJ>;
+        };
+    };
+
+    keymap {
+      compatible = "zmk,keymap";
+
+      default_layer {
+        bindings = <
+          &kp ESC   &kp DE_1     &kp DE_2     &kp DE_3      &kp DE_4         &kp DE_5 &tog KPAD                                                                    &mo ADJ     &kp DE_6   &kp DE_7  &kp DE_8  &kp DE_9 &kp DE_0    &kp DE_SS
+          &kp TAB   &kp Q        &kp W        &kp E         &kp R            &kp T    &kp WPSCR                                                                    &none       &kp DE_Z   &kp U     &kp I     &kp O    &kp P       &kp DE_UDIA
+          &kp BSPC  &kp A        &kp S        &kp D         &kp F            &kp G    &kp WPWIN           &kp LCTRL &none             &none     &kp RCTRL          &kp WNWIN   &kp H      &kp J     &kp K     &kp L    &kp DE_ODIA &kp DE_ADIA
+          &kp LSHFT &kp DE_Y     &kp X        &kp C         &kp V            &kp B              &none     &none     &none &none &none &kp PG_UP &none     &none                &kp N      &kp M     &kp COMMA &kp DOT  &kp FSLH    &kp RSHFT
+          &mo FN     &caps_word   &kp LEFT_GUI &kp LEFT_ALT  &kp LEFT_CONTROL                   &mo LOWER &kp ENTER &none             &kp BSPC  &kp SPACE &mo RAISE            &kp RCTRL  &kp RALT  &kp RGUI &none    &mo FN
+        >;
+      };
+      LOWER {
+        bindings = <
+          &kp DE_TILD &kp DE_1    &kp DE_2    &kp DE_3     &kp DE_4    &kp DE_5    &none                                                                        &none &kp DE_6   &kp DE_7    &kp DE_8    &kp DE_9    &kp DE_0    &none
+          &kp DE_SQT  &none       &kp W       &kp E        &kp R       &kp T       &none                                                                        &none &kp DE_Z   &kp U       &kp I       &kp O       &kp P       &kp DE_UDIA
+          &kp BSPC    &kp DE_EXCL &kp DE_AT   &kp DE_HASH  &kp DE_DLR  &kp DE_PERC &none          &kp LCTRL &kp LALT             &kp LGUI  &kp RCTRL            &none &kp DE_GRV &kp DE_AMPS &kp DE_STAR &kp DE_LPAR &kp DE_RPAR &kp DE_PIPE
+          &kp LSHFT   &kp DE_EQL  &kp DE_MINS &kp DE_PLUS  &kp DE_LBRC &kp DE_RBRC       &none    &none     &kp HOME &none &none &kp PG_UP &none     &none            &kp DE_LBKT&kp DE_RBKT &kp DE_RABK &kp DE_LABK &kp DE_BSLH &kp RSHFT
+          &none       &kp GRAVE   &kp CAPS    &kp LEFT     &kp RIGHT                     &trans   &trans    &kp END              &kp PG_DN &trans    &trans           &kp UP     &kp DOWN    &kp RBKT    &kp LBKT    &none
+        >;
+      };
+      RAISE {
+        bindings = <
+          &kp ESC   &kp DE_1  &kp DE_2  &kp DE_3  &kp DE_4   &kp DE_5 &none                                                                                  &none        &kp DE_6     &kp DE_7     &kp DE_8  &kp DE_9      &kp DE_0     &none
+          &kp TAB   &none     &kp PSCRN &none     &kp LC(R)  &none    &kp WTASK                                                                              &none        &kp LC(DE_Z) &kp RA(LEFT) &kp UP    &kp LA(RIGHT) &kp RC(BSPC) &none
+          &kp BSPC  &none     &none     &none     &none      &none    &kp C_VOL_DN             &kp LCTRL &kp LALT                 &kp LGUI  &kp RCTRL        &kp C_VOL_UP &none        &kp LEFT     &kp DOWN  &kp RIGHT     &kp DEL      &kp BSPC
+          &kp LSHFT &none     &kp LC(X) &kp LC(C) &kp LC(V)  &none                   &none     &none     &kp HOME  &none    &none &kp PG_UP &none     &none               &none        &none        &none     &none         &none        &kp RSHFT
+          &none     &none     &none     &none     &none                              &trans    &trans    &kp END                  &kp PG_DN &trans    &trans              &none        &kp DOWN     &kp LBKT  &kp RBKT      &none
+        >;
+      };
+      ADJ {
+        bindings = <
+          &none &bt BT_SEL 0 &bt BT_SEL 1 &bt BT_SEL 2 &bt BT_SEL 3 &bt BT_SEL 4 &none                                                                                                          &trans                 &bt BT_SEL 0 &bt BT_SEL 1 &bt BT_SEL 2 &bt BT_SEL 3 &bt BT_SEL 4 &none
+          &none &none        &none        &none        &none        &none        &bootloader                                                                                                    &bootloader            &none        &none        &none        &none        &none        &none
+          &none &none        &none        &none        &none        &none        &rgb_ug RGB_MEFS_CMD 5                 &bt BT_CLR &bt BT_CLR             &bt BT_CLR &bt BT_CLR                 &rgb_ug RGB_MEFS_CMD 5 &none        &none        &kp C_MUTE   &none        &none        &none
+          &none &none        &none        &none        &macro_ver   &none                               &none           &none      &none      &none &none &none      &none      &none                                  &none        &kp C_PREV   &kp C_PP     &kp C_NEXT   &none        &none
+          &none &none        &none        &bl BL_INC   &bl BL_DEC                                       &rgb_ug RGB_TOG &bl BL_TOG &none                  &none      &bl BL_TOG &rgb_ug RGB_TOG                                     &bl BL_INC   &bl BL_DEC   &none        &none        &none
+        >;
+      };
+      KPAD {
+        bindings = <
+          &kp EQUAL &kp N1    &kp N2   &kp N3   &kp N4     &kp N5 &trans                                                                       &mo ADJ &kp N6 &kp KP_NUM &kp KP_EQUAL &kp KP_DIVIDE &kp KP_MULTIPLY &kp MINUS
+          &kp TAB   &kp Q     &kp W    &kp E    &kp R      &kp T  &none                                                                        &none   &kp Y  &kp KP_N7  &kp KP_N8    &kp KP_N9     &kp KP_MINUS    &kp BSLH
+          &kp ESC   &kp A     &kp S    &kp D    &kp F      &kp G  &none           &kp LCTRL &kp LALT             &kp LGUI  &kp RCTRL           &none   &kp H  &kp KP_N4  &kp KP_N5    &kp KP_N6     &kp KP_PLUS     &kp SQT
+          &kp LSHFT &kp Z     &kp X    &kp C    &kp V      &kp B         &none    &none     &kp HOME &none &none &kp PG_UP &none     &none             &kp N  &kp KP_N1  &kp KP_N2    &kp KP_N3     &kp KP_ENTER    &kp RSHFT
+          &mo 2     &kp GRAVE &kp CAPS &kp LEFT &kp RIGHT                &trans   &trans    &trans               &kp PG_DN &trans    &trans            &kp UP  &kp DOWN  &kp KP_DOT   &kp RBKT      &mo FN
+        >;
+      };
+      FN {
+        bindings = <
+          &kp F1 &kp F2 &kp F3 &kp F4 &kp F5 &kp F6  &none                                                       &none &kp F7 &kp F8 &kp F9 &kp F10 &kp F11 &kp F12
+          &trans &trans &trans &trans &trans &trans  &none                                                       &none &trans &trans &trans &trans  &trans  &trans
+          &trans &trans &trans &trans &trans &trans  &none        &trans &trans             &trans &trans        &none &trans &trans &trans &trans  &trans  &trans
+          &trans &trans &trans &trans &trans &trans        &none  &none  &trans &none &none &trans &none  &none        &trans &trans &trans &trans  &trans  &trans
+          &trans &trans &trans &trans &trans               &trans &trans &trans             &trans &trans &trans              &trans &trans &trans  &trans  &trans
+        >;
+      };
+    };
+  };
+  

--- a/config/adv360_left.keymap
+++ b/config/adv360_left.keymap
@@ -5,4 +5,4 @@
 *
 */
 
-#include "adv360.keymap"
+#include "adv360_custom.keymap"

--- a/config/adv360_right.keymap
+++ b/config/adv360_right.keymap
@@ -5,4 +5,4 @@
 *
 */
 
-#include "adv360.keymap"
+#include "adv360_custom.keymap"

--- a/config/keymap_german.h
+++ b/config/keymap_german.h
@@ -1,0 +1,161 @@
+/* Copyright 2015-2016 Matthias Schmidtt
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <behaviors.dtsi>
+#include <dt-bindings/zmk/keys.h>
+#include <dt-bindings/zmk/bt.h>
+#include <dt-bindings/zmk/outputs.h>
+
+// clang-format off
+
+/*
+ * ┌───┬───┬───┬───┬───┬───┬───┬───┬───┬───┬───┬───┬───┬───────┐
+ * │ ^ │ 1 │ 2 │ 3 │ 4 │ 5 │ 6 │ 7 │ 8 │ 9 │ 0 │ ß │ ´ │       │
+ * ├───┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─────┤
+ * │     │ Q │ W │ E │ R │ T │ Z │ U │ I │ O │ P │ Ü │ + │     │
+ * ├─────┴┬──┴┬──┴┬──┴┬──┴┬──┴┬──┴┬──┴┬──┴┬──┴┬──┴┬──┴┬──┴┐    │
+ * │      │ A │ S │ D │ F │ G │ H │ J │ K │ L │ Ö │ Ä │ # │    │
+ * ├────┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴───┴────┤
+ * │    │ < │ Y │ X │ C │ V │ B │ N │ M │ , │ . │ - │          │
+ * ├────┼───┴┬──┴─┬─┴───┴───┴───┴───┴───┴──┬┴───┼───┴┬────┬────┤
+ * │    │    │    │                        │    │    │    │    │
+ * └────┴────┴────┴────────────────────────┴────┴────┴────┴────┘
+ */
+// Row 1
+#define DE_CIRC GRAVE // ^ (dead)
+#define MAC_CIRC NUBS // ^ (dead | mac)
+#define DE_1    N1    // 1
+#define DE_2    N2    // 2
+#define DE_3    N3    // 3
+#define DE_4    N4    // 4
+#define DE_5    N5    // 5
+#define DE_6    N6    // 6
+#define DE_7    N7    // 7
+#define DE_8    N8    // 8
+#define DE_9    N9    // 9
+#define DE_0    N0    // 0
+#define DE_SS   MINUS // ß
+#define DE_ACUT EQUAL // ´ (dead)
+// Row 2
+#define DE_Q    Q    // Q
+#define DE_W    W    // W
+#define DE_E    E    // E
+#define DE_R    R    // R
+#define DE_T    T    // T
+#define DE_Z    Y    // Z
+#define DE_U    U    // U
+#define DE_I    I    // I
+#define DE_O    O    // O
+#define DE_P    P    // P
+#define DE_UDIA LBKT // Ü
+#define DE_PLUS RBKT // +
+// Row 3
+#define DE_A    A    // A
+#define DE_S    S    // S
+#define DE_D    D    // D
+#define DE_F    F    // F
+#define DE_G    G    // G
+#define DE_H    H    // H
+#define DE_J    J    // J
+#define DE_K    K    // K
+#define DE_L    L    // L
+#define DE_ODIA SEMI // Ö
+#define DE_ADIA SQT  // Ä
+#define DE_HASH NUHS // #
+// Row 4
+#define DE_LABK NUBS // <
+#define MAC_LABK GRAVE // < (mac)
+#define DE_Y    Z    // Y
+#define DE_X    X    // X
+#define DE_C    C    // C
+#define DE_V    V    // V
+#define DE_B    B    // B
+#define DE_N    N    // N
+#define DE_M    M    // M
+#define DE_COMM COMMA // ,
+#define DE_DOT  DOT  // .
+#define DE_MINS FSLH // -
+
+/* Shifted symbols
+ * ┌───┬───┬───┬───┬───┬───┬───┬───┬───┬───┬───┬───┬───┬───────┐
+ * │ ° │ ! │ " │ § │ $ │ % │ & │ / │ ( │ ) │ = │ ? │ ` │       │
+ * ├───┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─────┤
+ * │     │   │   │   │   │   │   │   │   │   │   │   │ * │     │
+ * ├─────┴┬──┴┬──┴┬──┴┬──┴┬──┴┬──┴┬──┴┬──┴┬──┴┬──┴┬──┴┬──┴┐    │
+ * │      │   │   │   │   │   │   │   │   │   │   │   │ ' │    │
+ * ├────┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴───┴────┤
+ * │    │ > │   │   │   │   │   │   │   │ ; │ : │ _ │          │
+ * ├────┼───┴┬──┴─┬─┴───┴───┴───┴───┴───┴──┬┴───┼───┴┬────┬────┤
+ * │    │    │    │                        │    │    │    │    │
+ * └────┴────┴────┴────────────────────────┴────┴────┴────┴────┘
+ */
+// Row 1
+#define DE_DEG  LS(DE_CIRC) // °
+#define MAC_DEG LS(MAC_CIRC) // °
+#define DE_EXCL LS(DE_1)    // !
+#define DE_DQT  LS(DE_2)    // "
+#define DE_SECT LS(DE_3)    // §
+#define DE_DLR  LS(DE_4)    // $
+#define DE_PERC LS(DE_5)    // %
+#define DE_AMPS LS(DE_6)    // &
+#define DE_FSLH LS(DE_7)    // /
+#define DE_LPAR LS(DE_8)    // (
+#define DE_RPAR LS(DE_9)    // )
+#define DE_EQL  LS(DE_0)    // =
+#define DE_QUES LS(DE_SS)   // ?
+#define DE_GRV  LS(DE_ACUT) // ` (dead)
+// Row 2
+#define DE_STAR LS(DE_PLUS) // *
+// Row 3
+#define DE_SQT  LS(DE_HASH) // '
+// Row 4
+#define DE_RABK LS(DE_LABK) // >
+#define MAC_RABK LS(MAC_LABK) // > (mac)
+#define DE_SEMI LS(DE_COMM) // ;
+#define DE_COLN LS(DE_DOT)  // :
+#define DE_UNDS LS(DE_MINS) // _
+
+/* AltGr symbols
+ * ┌───┬───┬───┬───┬───┬───┬───┬───┬───┬───┬───┬───┬───┬───────┐
+ * │   │   │ ² │ ³ │   │   │   │ { │ [ │ ] │ } │ \ │   │       │
+ * ├───┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─────┤
+ * │     │ @ │   │ € │   │   │   │   │   │   │   │   │ ~ │     │
+ * ├─────┴┬──┴┬──┴┬──┴┬──┴┬──┴┬──┴┬──┴┬──┴┬──┴┬──┴┬──┴┬──┴┐    │
+ * │      │   │   │   │   │   │   │   │   │   │   │   │   │    │
+ * ├────┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴───┴────┤
+ * │    │ | │   │   │   │   │   │   │ µ │   │   │   │          │
+ * ├────┼───┴┬──┴─┬─┴───┴───┴───┴───┴───┴──┬┴───┼───┴┬────┬────┤
+ * │    │    │    │                        │    │    │    │    │
+ * └────┴────┴────┴────────────────────────┴────┴────┴────┴────┘
+ */
+// Row 1
+#define DE_SUP2 RA(DE_2)    // ²
+#define DE_SUP3 RA(DE_3)    // ³
+#define DE_LBRC RA(DE_7)    // {
+#define DE_LBKT RA(DE_8)    // [
+#define DE_RBKT RA(DE_9)    // ]
+#define DE_RBRC RA(DE_0)    // }
+#define DE_BSLH RA(DE_SS)   // (backslash)
+// Row 2
+#define DE_AT   RA(DE_Q)    // @
+#define DE_EURO RA(DE_E)    // €
+#define DE_TILD RA(DE_PLUS) // ~
+// Row 4
+#define DE_PIPE RA(DE_LABK) // |
+#define MAC_PIPE RA(MAC_LABK) // | (mac)
+#define DE_MICR RA(DE_M)    // µ

--- a/config/version.dtsi
+++ b/config/version.dtsi
@@ -1,0 +1,6 @@
+#define VERSION_MACRO
+macro_ver: macro_ver {
+compatible = "zmk,behavior-macro";
+#binding-cells = <0>;
+bindings = <&kp N2>, <&kp N0>, <&kp N2>, <&kp N5>, <&kp N0>, <&kp N6>, <&kp N1>, <&kp N6>, <&kp MINUS>, <&kp G>, <&kp E>, <&kp R>, <&kp M>, <&kp MINUS>, <&kp N0>, <&kp N9>, <&kp N1>, <&kp A>, <&kp N5>, <&kp D>, <&kp N4>, <&kp MINUS>, <&kp C>, <&kp L>, <&kp I>, <&kp Q>, <&kp U>, <&kp E>, <&kp RET>;
+};


### PR DESCRIPTION
## Summary
- Migrates German keyboard layout customizations from old customization branch to V3.0
- Updates repository with latest upstream changes from KinesisCorporation/Adv360-Pro-ZMK
- Adds complete German keymap with custom layer definitions and Windows shortcuts

## Changes Made
- **German keymap header** (`keymap_german.h`): Complete German layout definitions with DE_ key mappings
- **Custom German keymap** (`adv360_custom.keymap`): 
  - 6 layers: DEFAULT, LOWER, RAISE, ADJ, KPAD, FN
  - German QWERTZ layout with Ä, Ö, Ü, ß keys
  - Windows shortcuts (screenshot, window switching, task manager)
  - Conditional tri-layer support
  - Version macro integration
- **Build configuration**: Updated to use German keymap instead of default
- **Development environment**: Added devcontainer support

## Test Plan
- [ ] Build firmware using Docker (`make` or manual Docker commands)
- [ ] Flash left and right firmware files
- [ ] Test German key mappings (Ä, Ö, Ü, ß)
- [ ] Verify layer switching and shortcuts work correctly
- [ ] Test version macro (Mod+V)

## Migration Notes
- Successfully merged upstream V3.0 changes
- Resolved syntax errors from original customization branch
- Updated to V3.0 keymap structure (removed deprecated display-name properties)
- Compatible with latest ZMK features including Clique support

🤖 Generated with [Claude Code](https://claude.ai/code)