### PR TITLE
fix(ci): correct cache key path for west manifest

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,7 +31,7 @@ jobs:
             zephyr/
             bootloader/
             zmk/
-          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('manifest-dir/west.yml') }}
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('config/west.yml') }}
           restore-keys: |
             ${{ runner.os }}-build-${{ env.cache-name }}-
             ${{ runner.os }}-build-
@@ -87,7 +87,7 @@ jobs:
             zephyr/
             bootloader/
             zmk/
-          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('manifest-dir/west.yml') }}
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('config/west.yml') }}
           restore-keys: |
             ${{ runner.os }}-build-${{ env.cache-name }}-
             ${{ runner.os }}-build-


### PR DESCRIPTION
## Advantage 360 Pro PR template

### What's changed:

Corrects cache key in CI. Prior to this, the path pointed to a file that didn't exist, so the hash didn't function as intended (changing the file would not change the hash). Caching does help so it's worth not just ripping out, you can see on my fork:

Cold clique run: 5m34s total (334s)
Warm clique run: 2m04s total (124s)
Delta: -3m30s (~63%)

### Why has this change been implemented:

Cache better work faster. I was playing around with changes and noticed this one.

### What (if any) actions must a user take after this change:

N/A