### PR TITLE
Upgrade Github Actions to target Node.js 24 (V3.0-Japanese)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,7 +10,7 @@ jobs:
     name: Build (Legacy)
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Get version data
         id: get_info
         run: |
@@ -21,7 +21,7 @@ jobs:
           echo "file_prefix=$file_prefix" >> $GITHUB_OUTPUT
           bin/get_version.sh $branch_name $commit
       - name: Cache west modules
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         env:
           cache-name: cache-zephyr-modules
         with:
@@ -53,7 +53,7 @@ jobs:
       - name: Rename zmk.uf2
         run: cp build/left/zephyr/zmk.uf2 ${{ steps.get_info.outputs.file_prefix }}-left.uf2 && cp build/right/zephyr/zmk.uf2 ${{ steps.get_info.outputs.file_prefix }}-right.uf2
       - name: Archive (Adv360)
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: firmware-no-clique
           path: |
@@ -66,7 +66,7 @@ jobs:
     name: Build (Clique)
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Get version data
         id: get_info
         run: |
@@ -77,7 +77,7 @@ jobs:
           echo "file_prefix=$file_prefix" >> $GITHUB_OUTPUT
           bin/get_version.sh $branch_name $commit clique
       - name: Cache west modules
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         env:
           cache-name: cache-zephyr-modules
         with:
@@ -109,7 +109,7 @@ jobs:
       - name: Rename zmk.uf2
         run: cp build/left/zephyr/zmk.uf2 ${{ steps.get_info.outputs.file_prefix }}-left.uf2 && cp build/right/zephyr/zmk.uf2 ${{ steps.get_info.outputs.file_prefix }}-right.uf2
       - name: Archive (Adv360)
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: firmware-clique
           path: |


### PR DESCRIPTION
## What's changed:

Bump GitHub Actions to versions that target Node.js 24:

- `actions/checkout@v4` → `v6`
- `actions/cache@v4` → `v5`
- `actions/upload-artifact@v4` → `v7`

## Why has this change been implemented:

The current actions target Node.js 20, which has been deprecated by GitHub Actions.

CI logs show:

> Node.js 20 is deprecated. The following actions target Node.js 20 but are being forced to run on Node.js 24: actions/cache@v4, actions/checkout@v4, actions/upload-artifact@v4

Per GitHub's official announcement:
https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/

- **Since June 16, 2026**: Node.js 20 actions are forced to run on Node.js 24.
- **On September 16, 2026**: Node.js 20 will be removed from the runner.

Verified that the upgraded versions build successfully on a fork: https://github.com/polisherm/Adv360-Pro-ZMK/actions/runs/27867285362

Sister PR for V3.0 branch: #839

## What (if any) actions must a user take after this change:

None. Workflow behavior is unchanged.